### PR TITLE
Use autodiff to compute derivative of loss

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["David Hong <dahong67@wharton.upenn.edu> and contributors"]
 version = "0.1.0"
 
 [deps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LBFGSB = "5be7bae1-8223-5378-bac3-9e7378a2f6e6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 


### PR DESCRIPTION
Currently, using `gcp` with a custom loss requires providing both the function and gradient:
https://github.com/dahong67/GCPDecompositions.jl/blob/116db757bf621df7248d34347a797a3fb9d3b971/src/gcp-opt.jl#L17-L18

Besides being less user-friendly, there is a potential for incorrect results if the user provides only the function but forgets to provide the gradient (in which case the code would use the default, i.e., least squares).

The goal of this PR is to replace the current default gradient with one that is computed from the function `func` via (forward-mode) automatic differentiation.