### PR TITLE
Restrict LossFunctions.jl support to DistanceLoss and MarginLoss

### DIFF
--- a/ext/LossFunctionsExt.jl
+++ b/ext/LossFunctionsExt.jl
@@ -2,6 +2,8 @@ module LossFunctionsExt
 
 using GCPDecompositions, LossFunctions
 
+const SupportedLosses = Union{LossFunctions.DistanceLoss,LossFunctions.MarginLoss}
+
 """
     gcp(X::Array, r, loss::LossFunctions.SupervisedLoss[, lower]) -> CPD
 
@@ -15,7 +17,7 @@ with respect to the loss function `loss` and return a `CPD` object.
   - `loss` : loss function from LossFunctions.jl
   - `lower` : lower bound for factor matrix entries, `default = -Inf`
 """
-GCPDecompositions.gcp(X::Array, r, loss::LossFunctions.SupervisedLoss, lower = -Inf) =
+GCPDecompositions.gcp(X::Array, r, loss::SupportedLosses, lower = -Inf) =
     GCPDecompositions._gcp(
         X,
         r,


### PR DESCRIPTION
Some of the other loss functions `loss::SupervisedLoss` need the model tensor to have entries bounded above, e.g., `CrossEntropyLoss` needs the entries to be in `(0, 1)`. We don't support upper bounds (yet).

Should be fine for `loss::DistanceLoss` and `loss::MarginLoss`.