### PR TITLE
Eagerly instantiate the matricized tensor in mttkrp

### DIFF
--- a/src/gcp-opt.jl
+++ b/src/gcp-opt.jl
@@ -181,7 +181,7 @@ function mttkrp(X, U, n)
     (N == ndims(X) && I == size(X)) || throw(DimensionMismatch("`X` and `U` do not have matching dimensions"))
 
     # Matricized tensor (in mode n)
-    Xn = collect(reshape(PermutedDimsArray(X, [n; setdiff(1:N, n)]), size(X, n), :))
+    Xn = reshape(permutedims(X, [n; setdiff(1:N, n)]), size(X, n), :)
 
     # Khatri-Rao product (in mode n)
     Zn = similar(U[1], prod(I[setdiff(1:N, n)]), r)

--- a/src/gcp-opt.jl
+++ b/src/gcp-opt.jl
@@ -181,7 +181,7 @@ function mttkrp(X, U, n)
     (N == ndims(X) && I == size(X)) || throw(DimensionMismatch("`X` and `U` do not have matching dimensions"))
 
     # Matricized tensor (in mode n)
-    Xn = reshape(PermutedDimsArray(X, [n; setdiff(1:N, n)]), size(X, n), :)
+    Xn = collect(reshape(PermutedDimsArray(X, [n; setdiff(1:N, n)]), size(X, n), :))
 
     # Khatri-Rao product (in mode n)
     Zn = similar(U[1], prod(I[setdiff(1:N, n)]), r)


### PR DESCRIPTION
The current code forms a lazy matricization of the tensor:
https://github.com/dahong67/GCPDecompositions.jl/blob/1859ee2b0cee049423b8efd19446a2d77fd5e6d2/src/gcp-opt.jl#L183-L184

This PR instead eagerly instantiates/forms the matricization in memory.

Pros:
+ can speed up the multiply (use optimized routines, etc.)

Cons:
+ uses more memory/time to form the matricized tensor in memory