### PR TITLE
Add `norm` method for `CPD`

### DIFF
--- a/src/GCPDecompositions.jl
+++ b/src/GCPDecompositions.jl
@@ -7,10 +7,11 @@ module GCPDecompositions
 import Base: require_one_based_indexing
 import Base: ndims, size, show, summary
 import Base: getindex
+import LinearAlgebra: norm
 import ForwardDiff
 using Compat
 using IntervalSets
-using LinearAlgebra: mul!, rmul!, Diagonal, norm
+using LinearAlgebra: mul!, rmul!, Diagonal
 using LBFGSB: lbfgsb
 
 # Exports

--- a/src/gcp-opt.jl
+++ b/src/gcp-opt.jl
@@ -154,7 +154,7 @@ function _gcp(
 
     # Random initialization
     M0 = CPD(ones(T, r), rand.(T, size(X), r))
-    M0norm = sqrt(sum(abs2, M0[I] for I in CartesianIndices(size(M0))))
+    M0norm = norm(M0)
     Xnorm = sqrt(sum(abs2, skipmissing(X)))
     for k in Base.OneTo(N)
         M0.U[k] .*= (Xnorm / M0norm)^(1 / N)

--- a/src/type-cpd.jl
+++ b/src/type-cpd.jl
@@ -86,3 +86,10 @@ function getindex(M::CPD{T,N}, I::Vararg{Int,N}) where {T,N}
     )
 end
 getindex(M::CPD{T,N}, I::CartesianIndex{N}) where {T,N} = getindex(M, Tuple(I)...)
+
+norm(M::CPD, p::Real = 2) =
+    p == 2 ? norm2(M) : norm((M[I] for I in CartesianIndices(size(M))), p)
+function norm2(M::CPD{T,N}) where {T,N}
+    V = reduce(.*, M.U[i]'M.U[i] for i in 1:N)
+    return sqrt(abs(M.λ' * V * M.λ))
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LossFunctions = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/items/type-cpd.jl
+++ b/test/items/type-cpd.jl
@@ -121,3 +121,39 @@ end
         @test_throws BoundsError M[size(U1, 1)+1]
     end
 end
+
+@testitem "norm" begin
+    using LinearAlgebra
+
+    @testset "K=$K" for K in 0:2
+        T = Float64
+        λfull = T[1, 100, 10000]
+        U1full, U2full, U3full = T[1 2 3; 4 5 6], T[-1 0 1], T[1 2 3; 4 5 6; 7 8 9]
+        λ = λfull[1:K]
+        U1, U2, U3 = U1full[:, 1:K], U2full[:, 1:K], U3full[:, 1:K]
+
+        M = CPD(λ, (U1, U2, U3))
+        @test norm(M) ==
+              norm(M, 2) ==
+              sqrt(sum(abs2, M[I] for I in CartesianIndices(size(M))))
+        @test norm(M, 1) == sum(abs, M[I] for I in CartesianIndices(size(M)))
+        @test norm(M, 3) ==
+              (sum(m -> abs(m)^3, M[I] for I in CartesianIndices(size(M))))^(1 / 3)
+
+        M = CPD(λ, (U1, U2))
+        @test norm(M) ==
+              norm(M, 2) ==
+              sqrt(sum(abs2, M[I] for I in CartesianIndices(size(M))))
+        @test norm(M, 1) == sum(abs, M[I] for I in CartesianIndices(size(M)))
+        @test norm(M, 3) ==
+              (sum(m -> abs(m)^3, M[I] for I in CartesianIndices(size(M))))^(1 / 3)
+
+        M = CPD(λ, (U1,))
+        @test norm(M) ==
+              norm(M, 2) ==
+              sqrt(sum(abs2, M[I] for I in CartesianIndices(size(M))))
+        @test norm(M, 1) == sum(abs, M[I] for I in CartesianIndices(size(M)))
+        @test norm(M, 3) ==
+              (sum(m -> abs(m)^3, M[I] for I in CartesianIndices(size(M))))^(1 / 3)
+    end
+end


### PR DESCRIPTION
With the recent improvements in MTTKRP (e.g., #35, #41, and #43), it seems that computing the norm of `M0::CPD` is now a bottleneck in `gcp` as seen in the following profile.

![image](https://github.com/dahong67/GCPDecompositions.jl/assets/9384655/2adcc960-048f-4fe8-90ff-4b1ac909b634)

This PR implements a more efficient version.