### PR TITLE
Rename `ncomponents` to `ncomps`

### DIFF
--- a/docs/src/demos/amino-acids.jl
+++ b/docs/src/demos/amino-acids.jl
@@ -159,7 +159,7 @@ with_theme() do
 	fig = Figure()
 
 	# Plot factors (normalized by max)
-	for row in 1:ncomponents(M)
+	for row in 1:ncomps(M)
 		barplot(fig[row,1], 1:size(X,1), normalize(M.U[1][:,row], Inf))
 		lines(fig[row,2], em_wave, normalize(M.U[2][:,row], Inf))
 		lines(fig[row,3], ex_wave, normalize(M.U[3][:,row], Inf))

--- a/docs/src/demos/monkey-bmi.jl
+++ b/docs/src/demos/monkey-bmi.jl
@@ -240,7 +240,7 @@ with_theme() do
 	fig = Figure(; size = (700, 700))
 
 	# Plot factors (normalized by max)
-	for row in 1:ncomponents(M)
+	for row in 1:ncomps(M)
 		barplot(fig[row,1], normalize(M.U[1][:,row], Inf); color = :orange)
 		lines(fig[row,2], normalize(M.U[2][:,row], Inf); linewidth = 4)
 		scatter(fig[row,3], normalize(M.U[3][:,row], Inf);

--- a/docs/src/man/main.md
+++ b/docs/src/man/main.md
@@ -8,7 +8,7 @@
 GCPDecompositions
 gcp
 CPD
-ncomponents
+ncomps
 GCPDecompositions.default_constraints
 GCPDecompositions.default_algorithm
 GCPDecompositions.default_init

--- a/src/GCPDecompositions.jl
+++ b/src/GCPDecompositions.jl
@@ -12,7 +12,7 @@ using Random: default_rng
 
 # Exports
 export CPD
-export ncomponents
+export ncomps
 export gcp
 export GCPLosses, GCPConstraints, GCPAlgorithms
 

--- a/src/cpd.jl
+++ b/src/cpd.jl
@@ -32,13 +32,13 @@ CPD(λ::Tλ, U::NTuple{N,TU}) where {T,N,Tλ<:AbstractVector{T},TU<:AbstractMatr
     CPD{T,N,Tλ,TU}(λ, U)
 
 """
-    ncomponents(M::CPD)
+    ncomps(M::CPD)
 
 Return the number of components in `M`.
 
 See also: `ndims`, `size`.
 """
-ncomponents(M::CPD) = length(M.λ)
+ncomps(M::CPD) = length(M.λ)
 ndims(::CPD{T,N}) where {T,N} = N
 
 size(M::CPD{T,N}, dim::Integer) where {T,N} = dim <= N ? size(M.U[dim], 1) : 1
@@ -65,22 +65,22 @@ function summary(io::IO, M::CPD)
     dimstring =
         ndims(M) == 0 ? "0-dimensional" :
         ndims(M) == 1 ? "$(size(M,1))-element" : join(map(string, size(M)), '×')
-    ncomps = ncomponents(M)
+    _ncomps = ncomps(M)
     return print(
         io,
         dimstring,
         " ",
         typeof(M),
         " with ",
-        ncomps,
-        ncomps == 1 ? " component" : " components",
+        _ncomps,
+        _ncomps == 1 ? " component" : " components",
     )
 end
 
 function getindex(M::CPD{T,N}, I::Vararg{Int,N}) where {T,N}
     @boundscheck Base.checkbounds_indices(Bool, axes(M), I) || Base.throw_boundserror(M, I)
     val = zero(eltype(T))
-    for j in Base.OneTo(ncomponents(M))
+    for j in Base.OneTo(ncomps(M))
         val += M.λ[j] * prod(M.U[k][I[k], j] for k in Base.OneTo(ndims(M)))
     end
     return val

--- a/test/items/cpd.jl
+++ b/test/items/cpd.jl
@@ -27,25 +27,25 @@
     end
 end
 
-@testitem "ncomponents" begin
+@testitem "ncomps" begin
     λ = [1, 100, 10000]
     U1, U2, U3 = [1 2 3; 4 5 6], [-1 0 1], [1 2 3; 4 5 6; 7 8 9]
 
-    @test ncomponents(CPD(λ, (U1,))) ==
-          ncomponents(CPD(λ, (U1, U2))) ==
-          ncomponents(CPD(λ, (U1, U2, U3))) ==
+    @test ncomps(CPD(λ, (U1,))) ==
+          ncomps(CPD(λ, (U1, U2))) ==
+          ncomps(CPD(λ, (U1, U2, U3))) ==
           3
-    @test ncomponents(CPD(λ[1:2], (U1[:, 1:2],))) ==
-          ncomponents(CPD(λ[1:2], (U1[:, 1:2], U2[:, 1:2]))) ==
-          ncomponents(CPD(λ[1:2], (U1[:, 1:2], U2[:, 1:2], U3[:, 1:2]))) ==
+    @test ncomps(CPD(λ[1:2], (U1[:, 1:2],))) ==
+          ncomps(CPD(λ[1:2], (U1[:, 1:2], U2[:, 1:2]))) ==
+          ncomps(CPD(λ[1:2], (U1[:, 1:2], U2[:, 1:2], U3[:, 1:2]))) ==
           2
-    @test ncomponents(CPD(λ[1:1], (U1[:, 1:1],))) ==
-          ncomponents(CPD(λ[1:1], (U1[:, 1:1], U2[:, 1:1]))) ==
-          ncomponents(CPD(λ[1:1], (U1[:, 1:1], U2[:, 1:1], U3[:, 1:1]))) ==
+    @test ncomps(CPD(λ[1:1], (U1[:, 1:1],))) ==
+          ncomps(CPD(λ[1:1], (U1[:, 1:1], U2[:, 1:1]))) ==
+          ncomps(CPD(λ[1:1], (U1[:, 1:1], U2[:, 1:1], U3[:, 1:1]))) ==
           1
-    @test ncomponents(CPD(λ[1:0], (U1[:, 1:0],))) ==
-          ncomponents(CPD(λ[1:0], (U1[:, 1:0], U2[:, 1:0]))) ==
-          ncomponents(CPD(λ[1:0], (U1[:, 1:0], U2[:, 1:0], U3[:, 1:0]))) ==
+    @test ncomps(CPD(λ[1:0], (U1[:, 1:0],))) ==
+          ncomps(CPD(λ[1:0], (U1[:, 1:0], U2[:, 1:0]))) ==
+          ncomps(CPD(λ[1:0], (U1[:, 1:0], U2[:, 1:0], U3[:, 1:0]))) ==
           0
 end
 


### PR DESCRIPTION
Reasons:
- `ncomps` is more consistent with `ndims`
- prepares the way for `normalizecomps`, `mapcomps`, and `permutecomps` (which would be even longer with "components")